### PR TITLE
add user data to /auth/token route

### DIFF
--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -7,7 +7,16 @@ const authRoutes = (router) => {
   
   router.route("/auth/token")
     .get(validator.jwtHeader, controller.authenticateToken, (req, res) => {
-      res.success("user successfully authenticated via token");
+      const {user} = req;
+      const userData = {
+        user: {
+          username: user.username,
+          displayName: user.displayName,
+          createdOn: user.createdOn,
+          updatedOn: user.updatedOn
+        }
+      }
+      res.success("user successfully authenticated via token", userData);
     });
 };
 

--- a/test/auth_endpoints/authenticate_token.spec.js
+++ b/test/auth_endpoints/authenticate_token.spec.js
@@ -5,6 +5,7 @@ import {
   createTestUser,
   generateToken
 } from "../utils";
+import assert from "assert";
 const server = supertest.agent(`https://localhost:${port}`);
 
 describe("[Auth] Authenticate Token", () => {
@@ -106,9 +107,19 @@ describe("[Auth] Authenticate Token", () => {
       server
         .get("/auth/token")
         .set("x-needle-token", jwtToken)
-        .expect(200, {
-          message: "user successfully authenticated via token"
-        }, done);
+        .expect(200)
+        .end((err, res) => {
+          if(err)
+            return done(err);
+          
+          const {message, user} = res.body;
+          assert.equal(message, "user successfully authenticated via token");
+          assert(user);
+          assert(user.username, testUser.username);
+          assert(user.displayName, testUser.displayName);
+          assert(user.createdOn);
+          done();
+        });
     });
   });
 });


### PR DESCRIPTION
The UI is going to be utilizing the existing route `/auth/token` to validate stored tokens.
- Add user data to /auth/token success response.
- Update unit test.