### PR TITLE
Add membership roles to dashboard project list

### DIFF
--- a/src/controllers/dashboard.js
+++ b/src/controllers/dashboard.js
@@ -6,7 +6,7 @@ const get = (req, res) => {
   Membership
     .find({user: user._id})
     .sort({createdOn: "asc"})
-    .populate("project", "-description")
+    .populate("project")
     .exec((err, memberships) => {
       if(err)
         return res.fatalError(err);
@@ -24,6 +24,7 @@ const get = (req, res) => {
             projects: memberships.map(({project, roles}) => ({
               id: project._id,
               name: project.name,
+              description: project.description,
               isPrivate: project.isPrivate,
               isActive: project.isActive,
               createdOn: project.createdOn,

--- a/src/controllers/dashboard.js
+++ b/src/controllers/dashboard.js
@@ -21,13 +21,14 @@ const get = (req, res) => {
             return res.fatalError(err);
 
           const result = {
-            projects: memberships.map(({project}) => ({
+            projects: memberships.map(({project, roles}) => ({
               id: project._id,
               name: project.name,
               isPrivate: project.isPrivate,
               isActive: project.isActive,
               createdOn: project.createdOn,
-              updatedOn: project.updatedOn
+              updatedOn: project.updatedOn,
+              roles
             })),
             stories: stories.map(story => ({
               id: story._id,

--- a/src/controllers/project.js
+++ b/src/controllers/project.js
@@ -6,7 +6,7 @@ const create = (req, res) => {
   const user = req.user;
   Project.create({
     name,
-    description: description && description.length ? description : null,
+    description: description && description.length ? description : "",
     isPrivate: !!isPrivate,
     isActive: true,
     createdOn: new Date(),
@@ -93,7 +93,7 @@ const update = (req, res) => {
   if(description)
     project.description = description;
   else if(typeof description === "string" && !description.length)
-    project.description = null;
+    project.description = "";
   
   if(typeof isPrivate === "boolean")
     project.isPrivate = isPrivate;


### PR DESCRIPTION
This PR contains:
- update to dashboard endpoint, returning membership roles for each project.
- update project endpoints to use an empty-string for descriptions by default.
- update dashboard endpoint to include project descriptions.