### PR TITLE
Project updates

### DIFF
--- a/src/controllers/membership.js
+++ b/src/controllers/membership.js
@@ -39,7 +39,7 @@ const getAll = (req, res) => {
   Membership
     .find({project: project._id})
     .sort({createdOn: "asc"})
-    .populate("user", "-_id username displayName")
+    .populate("user", "-_id username displayName isActive")
     .skip(pageOffset)
     .limit(itemsPerPage)
     .exec((err, memberships) => {
@@ -54,13 +54,28 @@ const getAll = (req, res) => {
           id: project._id,
           name: project.name
         },
-        memberships: memberships.map(membership => ({
-          id: membership._id,
-          user: membership.user,
-          roles: membership.roles,
-          createdOn: membership.createdOn,
-          updatedOn: membership.updatedOn
-        }))
+        // memberships: memberships.map(membership => ({
+        //   id: membership._id,
+        //   user: membership.user,
+        //   roles: membership.roles,
+        //   createdOn: membership.createdOn,
+        //   updatedOn: membership.updatedOn
+        // })),
+        memberships: memberships.reduce((prev, curr) => {
+          if(curr.user.isActive) {
+            return prev.concat({
+              id: curr._id,
+              user: {
+                username: curr.user.username,
+                displayName: curr.user.displayName
+              },
+              roles: curr.roles,
+              createdOn: curr.createdOn,
+              updatedOn: curr.updatedOn
+            })
+          }
+          return prev;
+        }, [])
       };
 
       return res.success("membership list has been successfully retrieved", result);

--- a/src/controllers/project.js
+++ b/src/controllers/project.js
@@ -1,5 +1,6 @@
 import Project from "../models/project";
 import Membership from "../models/membership";
+import Story from "../models/story";
 
 const create = (req, res) => {
   const { name, description, isPrivate } = req.body;
@@ -72,6 +73,7 @@ const getAll = (req, res) => {
 };
 
 const getOne = (req, res) => {
+  const includeStatistics = req.query.includeStatistics && req.query.includeStatistics === "true";
   const project = req.project;
   const projectData = {
     id: project._id,
@@ -81,7 +83,27 @@ const getOne = (req, res) => {
     createdOn: project.createdOn,
     updatedOn: project.updatedOn
   };
-  return res.success("project has been successfully retrieved", {project: projectData});
+
+  if(includeStatistics){
+    Membership.count({project: project._id}, (err, membershipCount) => {
+      if(err)
+        return res.fatalError(err);
+      
+      Story.count({project: project._id}, (err, storyCount) => {
+        if(err)
+          return res.fatalError(err);
+        
+        projectData.statistics = {
+          memberships: membershipCount,
+          stories: storyCount
+        };
+        
+        return res.success("project has been successfully retrieved", {project: projectData});
+      });
+    });
+  }
+  else
+    return res.success("project has been successfully retrieved", {project: projectData});
 };
 
 const update = (req, res) => {

--- a/src/controllers/project.js
+++ b/src/controllers/project.js
@@ -85,11 +85,11 @@ const getOne = (req, res) => {
   };
 
   if(includeStatistics){
-    Membership.count({project: project._id}, (err, membershipCount) => {
+    Membership.countDocuments({project: project._id}, (err, membershipCount) => {
       if(err)
         return res.fatalError(err);
       
-      Story.count({project: project._id}, (err, storyCount) => {
+      Story.countDocuments({project: project._id}, (err, storyCount) => {
         if(err)
           return res.fatalError(err);
         


### PR DESCRIPTION
This PR contains the following:
- Updated Membership `getAll` route to filter out `inActive` Users.
- Updated Project `getOne` route to support the `includeStatistics` query-string, this will be utilized by the UI. Added test.