### PR TITLE
Update Project getOne

### DIFF
--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -91,6 +91,7 @@ const authorizeAdmin = (req, res, next) => {
     if(!membership.roles.isAdmin)
       return res.authorizationError("you must have admin permissions to perform this action");
     
+    req.requestMembership = membership;
     next();
   });
 };
@@ -116,6 +117,7 @@ const authorizeManager = (req, res, next) => {
     if(!membership.roles.isAdmin && !membership.roles.isManager)
       return res.authorizationError("you must have manager permissions to perform this action");
     
+    req.requestMembership = membership;
     next();
   });
 };
@@ -134,6 +136,7 @@ const authorizeDeveloper = (req, res, next) => {
     if(!isAdmin && !isManager && !isDeveloper)
       return res.authorizationError("you must have developer permissions to perform this action");
     
+    req.requestMembership = membership;
     next();
   });
 };
@@ -158,6 +161,7 @@ const authorizeViewer = (req, res, next) => {
     if(!isAdmin && !isManager && !isDeveloper && !isViewer)
       return res.authorizationError("you must have viewer permissions to perform this action");
     
+    req.requestMembership = membership;
     next();
   });
 };

--- a/src/controllers/project.js
+++ b/src/controllers/project.js
@@ -74,14 +74,17 @@ const getAll = (req, res) => {
 
 const getOne = (req, res) => {
   const includeStatistics = req.query.includeStatistics && req.query.includeStatistics === "true";
-  const project = req.project;
-  const projectData = {
-    id: project._id,
-    name: project.name,
-    description: project.description,
-    isPrivate: project.isPrivate,
-    createdOn: project.createdOn,
-    updatedOn: project.updatedOn
+  const {project, requestMembership} = req;
+  const responsePayload = {
+    project: {
+      id: project._id,
+      name: project.name,
+      description: project.description,
+      isPrivate: project.isPrivate,
+      createdOn: project.createdOn,
+      updatedOn: project.updatedOn
+    },
+    userRoles: requestMembership ? requestMembership.roles : null
   };
 
   if(includeStatistics){
@@ -93,17 +96,17 @@ const getOne = (req, res) => {
         if(err)
           return res.fatalError(err);
         
-        projectData.statistics = {
+        responsePayload.project.statistics = {
           memberships: membershipCount,
           stories: storyCount
         };
         
-        return res.success("project has been successfully retrieved", {project: projectData});
+        return res.success("project has been successfully retrieved", responsePayload);
       });
     });
   }
   else
-    return res.success("project has been successfully retrieved", {project: projectData});
+    return res.success("project has been successfully retrieved", responsePayload);
 };
 
 const update = (req, res) => {


### PR DESCRIPTION
When loading project details on the UI we want to know what permissions the requesting user has. Since the UI will allow user's to manage memberships and backlog stories. Knowing what roles a user has will allow the UI to allow/restrict certain actions involving a project.