### PR TITLE
Update Pagination Logic

### DIFF
--- a/src/utils/validator.js
+++ b/src/utils/validator.js
@@ -27,8 +27,10 @@ export const validatePaginationInput = (model, countQueryArgs, queryStringInput,
 
     const totalPages = Math.ceil(count / itemsPerPage);
     let page = Number(queryStringInput.page);
-    if(isNaN(page) || !Number.isInteger(Number(page)) || page <= 0 || page > totalPages)
+    if(isNaN(page) || !Number.isInteger(Number(page)) || page <= 0)
       page = 1;
+    else if(page > totalPages) // If the page is greater than the limit. set it to the limit.
+      page = totalPages;
     
     const pageOffset = (page - 1) * itemsPerPage;
     const paginationData = {


### PR DESCRIPTION
This PR updates pagination logic so that if a page passed to the API is greater than the total pages, it will default to the last page available. Previously, it defaulted to 1 but this logic does not provide a good user experience on the UI