### PR TITLE
Update Story getOne / Validation

### DIFF
--- a/src/controllers/story.js
+++ b/src/controllers/story.js
@@ -78,14 +78,15 @@ const getAll = (req, res) => {
 };
 
 const getOne = (req, res) => {
-  const { project, story } = req;
+  const { project, story, requestMembership } = req;
   const storyData = {
     id: story._id,
     name: story.name,
     details: story.details,
     project: {
       id: project._id,
-      name: project.name
+      name: project.name,
+      userRoles: requestMembership ? requestMembership.roles : null
     },
     creator: story.creator,
     owner: story.owner || null,

--- a/src/validators/story.js
+++ b/src/validators/story.js
@@ -20,8 +20,8 @@ const _validateName = (name, isOptional, callback) => {
   if(!compareType(name, "string"))
     return callback("name must be a string");
 
-  if(name.length < 1 || name.length > 300)
-    return callback("name must be 1 - 300 characters in length");
+  if(name.length < 1 || name.length > 100)
+    return callback("name must be 1 - 100 characters in length");
 
   const regex = new RegExp("^[A-Za-z0-9-_+=&^%$#*@!|\/(){}?.,<>;':\" ]+$");
   if(!regex.test(name))

--- a/test/story_endpoints/story_create.spec.js
+++ b/test/story_endpoints/story_create.spec.js
@@ -131,7 +131,7 @@ describe("[Story] Create", () => {
         .set("x-needle-token", authTokenDeveloper)
         .send(payload)
         .expect(400, {
-          error: "name must be 1 - 300 characters in length"
+          error: "name must be 1 - 100 characters in length"
         }, done);
     });
 
@@ -142,7 +142,7 @@ describe("[Story] Create", () => {
         .set("x-needle-token", authTokenDeveloper)
         .send(payload)
         .expect(400, {
-          error: "name must be 1 - 300 characters in length"
+          error: "name must be 1 - 100 characters in length"
         }, done);
     });
 

--- a/test/story_endpoints/story_update.spec.js
+++ b/test/story_endpoints/story_update.spec.js
@@ -143,7 +143,7 @@ describe("[Story] Update", () => {
         .set("x-needle-token", authTokenDeveloper)
         .send(payload)
         .expect(400, {
-          error: "name must be 1 - 300 characters in length"
+          error: "name must be 1 - 100 characters in length"
         }, done);
     });
 
@@ -154,7 +154,7 @@ describe("[Story] Update", () => {
         .set("x-needle-token", authTokenDeveloper)
         .send(payload)
         .expect(400, {
-          error: "name must be 1 - 300 characters in length"
+          error: "name must be 1 - 100 characters in length"
         }, done);
     });
 


### PR DESCRIPTION
The UI needed some changes made for development. This PR contains:
- Added `userRoles` to story `getOne` response.
- Updated Story `update` and `create` validation. Making the maximum name size 100 characters.