### PR TITLE
Add filterName support for Dashboard/Project Stories

### DIFF
--- a/src/controllers/dashboard.js
+++ b/src/controllers/dashboard.js
@@ -49,23 +49,26 @@ const getProjects = (req, res) => {
 };
 
 const getStories = (req, res) => {
-  const {user, memberProjects} = req;
+  const {user, memberProjects, query} = req;
   const {
     page,
     totalPages,
     itemsPerPage
   } = req.paginationData;
   const pageOffset = (page - 1) * itemsPerPage;
+  const queryArgs = {
+    $and: [
+      {$or: [
+        {owner: user._id},
+        {creator: user._id}
+      ]},
+      {project: {$in: memberProjects}}
+    ]
+  };
+  if(query.filterName)
+    queryArgs.name = {$regex: `^${escapeRegex(query.filterName)}`, $options: "i"}
   Story
-    .find({
-      $and: [
-        {$or: [
-          {owner: user._id},
-          {creator: user._id}
-        ]},
-        {project: {$in: memberProjects}}
-      ]
-    })
+    .find(queryArgs)
     .populate("creator", "-_id username displayName")
     .populate("owner", "-_id username displayName")
     .populate("project", "-description")

--- a/src/controllers/story.js
+++ b/src/controllers/story.js
@@ -1,4 +1,5 @@
 import Story from "../models/story";
+import {escapeRegex} from "../utils/validator";
 
 const create = (req, res) => {
   const { name, details } = req.body;
@@ -37,15 +38,18 @@ const create = (req, res) => {
 };
 
 const getAll = (req, res) => {
-  const { project } = req;
+  const { project, query } = req;
   const {
     page,
     totalPages,
     itemsPerPage
   } = req.paginationData;
   const pageOffset = (page - 1) * itemsPerPage;
+  const queryArgs = {project: project._id};
+  if(query.filterName)
+    queryArgs.name = {$regex: `^${escapeRegex(query.filterName)}`, $options: "i"};
   Story
-    .find({project: project._id})
+    .find(queryArgs)
     .sort({createdOn: "asc"})
     .populate("creator", "-_id username displayName")
     .populate("owner", "-_id username displayName")

--- a/src/validators/dashboard.js
+++ b/src/validators/dashboard.js
@@ -60,6 +60,8 @@ const getStories = (req, res, next) => {
               {project: {$in: activeMemberProjects}}
             ]
           };
+          if(query.filterName)
+            countQueryArgs.name = {$regex: `^${escapeRegex(query.filterName)}`, $options: "i"}
           
           validatePaginationInput(
             Story,

--- a/src/validators/story.js
+++ b/src/validators/story.js
@@ -7,7 +7,8 @@ import {
   isMissing, 
   validatePaginationInput, 
   getOneWithSlug,
-  validateConfirmBoolean
+  validateConfirmBoolean,
+  escapeRegex
 } from "../utils/validator";
 
 const _validateName = (name, isOptional, callback) => {
@@ -100,6 +101,8 @@ const create = (req, res, next) => {
 const getAll = (req, res, next) => {
   const { project, query } = req;
   const countQueryArgs = { project: project._id };
+  if(query.filterName)
+    countQueryArgs.name = {$regex: `^${escapeRegex(query.filterName)}`, $options: "i"};
   validatePaginationInput(
     Story,
     countQueryArgs,

--- a/test/dashboard_endpoints/dashboard_stories.spec.js
+++ b/test/dashboard_endpoints/dashboard_stories.spec.js
@@ -12,17 +12,19 @@ const server = supertest.agent(`https://localhost:${port}`);
 
 describe("[Dashboard] Get Stories", () => {
   let authToken;
+  let testStory;
   before(done => {
     createTestUser("Password1", (user) => {
       createTestProject(false, user, (project1) => {
         createTestProject(true, user, (project2) => {
           createTestProject(false, user, (project3) => {
-            createTestStory(project1, user, null, () => {
+            createTestStory(project1, user, null, (story) => {
               createTestStory(project1, user, null, () => {
                 createTestStory(project2, user, null, () => {
                   createTestStory(project2, user, null, () => {
                     createTestStory(project3, user, null, () => {
                       createTestStory(project3, user, null, () => {
+                        testStory = story;
                         project3.isActive = false;
                         project3.save(() => {
                           authToken = generateToken(user);
@@ -66,6 +68,24 @@ describe("[Dashboard] Get Stories", () => {
           assert.equal(message, "dashboard stories successfully retrieved");
           assert(stories);
           assert.equal(stories.length, 4);
+          done();
+        });
+    });
+
+    it("should successfully return dashboard stories filtered by name", (done) => {
+      server
+        .get(`/dashboard/stories?filterName=${testStory.name}`)
+        .set("x-needle-token", authToken)
+        .expect(200)
+        .end((err, res) => {
+          if(err)
+            return done(err);
+          
+          const {message, stories, page} = res.body;
+          assert.equal(message, "dashboard stories successfully retrieved");
+          assert.equal(page, 1);
+          assert.equal(stories.length, 1);
+          assert.equal(stories[0].name, testStory.name);
           done();
         });
     });

--- a/test/story_endpoints/story_get_all.spec.js
+++ b/test/story_endpoints/story_get_all.spec.js
@@ -138,5 +138,21 @@ describe("[Story] Get All", () => {
         .set("x-needle-token", authTokenNonMember)
         .expect(200, done);
     });
+
+    it("should successfully return a paginated list of stories filtered by name", (done) => {
+      server
+        .get(`/projects/${testProjectPrivate._id}/stories?filterName=${testStory.name}`)
+        .set("x-needle-token", authTokenAdmin)
+        .expect(200)
+        .end((err, res) => {
+          if(err)
+            return done(err);
+          
+          const { stories } = res.body;
+          assert.equal(stories.length, 1);
+          assert.equal(stories[0].name, testStory.name);
+          done();
+        });
+    });
   });
 });


### PR DESCRIPTION
This PR adds `filterName` support to the `/dashboard/stories` and `project/stories` endpoints. Allowing users to filter their results to only include stories that start with the filterName value.

Added unit tests.